### PR TITLE
Update PlanetHosterAPI.php

### DIFF
--- a/app/Libs/PlanetHosterAPI.php
+++ b/app/Libs/PlanetHosterAPI.php
@@ -13,7 +13,7 @@ class PlanetHosterAPI
 
     public function __construct($host, $apiUser, $apiKey, $httpprefix = 'https')
     {
-        $this->host = $host;
+        $this->host = 'api.planethoster.net';
         $this->apiUser = $apiUser;
         $this->apiKey = $apiKey;
         $this->apiVersion = 'v3';


### PR DESCRIPTION
Enforces the use of api.planethoster.net as the host. This change enables users to define any server using a white-label hostname without any issue with the api