### PR TITLE
Correctif SSO WHMCS : retour du format attendu ['success'=>true, 'red…

### DIFF
--- a/app/Configuration/Server/base.php
+++ b/app/Configuration/Server/base.php
@@ -67,20 +67,20 @@ function PlanetHoster_ConfigOptions($params = [])
     return (new AppContext())->runServerModule(__FUNCTION__, $params);
 }
 
-//function PlanetHoster_ServiceSingleSignon($params)
-//{
-//    return (new AppContext())->runServerModule(__FUNCTION__, $params);
-//}
+function PlanetHoster_ServiceSingleSignOn($params)
+{
+    return (new AppContext())->runServerModule(__FUNCTION__, $params);
+}
 
 //function PlanetHoster_MetaData()
 //{
 //    return (new AppContext())->runServerModule(__FUNCTION__, []);
 //}
 
-//function PlanetHoster_AdminSingleSignOn($params)
-//{
-//    return (new AppContext())->runServerModule(__FUNCTION__, $params);
-//}
+function PlanetHoster_AdminSingleSignOn($params)
+{
+    return (new AppContext())->runServerModule(__FUNCTION__, $params);
+}
 
 function PlanetHoster_AdminServicesTabFields($params)
 {

--- a/app/Http/Actions/AdminSingleSignOn.php
+++ b/app/Http/Actions/AdminSingleSignOn.php
@@ -2,12 +2,44 @@
 
 namespace ModulesGarden\PlanetHoster\App\Http\Actions;
 
+use ModulesGarden\PlanetHoster\App\Libs\PlanetHosterAPI;
 use ModulesGarden\PlanetHoster\Core\App\Controllers\Instances\Server\Action;
 
 class AdminSingleSignOn extends Action
 {
     public function execute($params = null)
     {
+        try {
+            if (empty($params['customfields']['account_id'])) {
+                return [
+                    'success' => false,
+                    'error' => 'Custom Field /Account ID/ is not empty'
+                ];
+            }
 
+            $api = new PlanetHosterAPI(
+                $params['serverhostname'],
+                $params['serverusername'],
+                $params['serverpassword'],
+                $params['serverhttpprefix']
+            );
+
+            $result = $api->loginPanel($params['customfields']['account_id']);
+            if (!empty($result['data']['login_url'])) {
+                return [
+                    'success' => true,
+                    'redirectTo' => $result['data']['login_url']
+                ];
+            }
+            return [
+                'success' => false,
+                'error' => 'SSO URL not found'
+            ];
+        } catch (\Exception $e) {
+            return [
+                'success' => false,
+                'error' => $e->getMessage()
+            ];
+        }
     }
 }

--- a/app/Http/Actions/ServiceSingleSignOn.php
+++ b/app/Http/Actions/ServiceSingleSignOn.php
@@ -2,12 +2,44 @@
 
 namespace ModulesGarden\PlanetHoster\App\Http\Actions;
 
+use ModulesGarden\PlanetHoster\App\Libs\PlanetHosterAPI;
 use ModulesGarden\PlanetHoster\Core\App\Controllers\Instances\Server\Action;
 
 class ServiceSingleSignOn extends Action
 {
     public function execute($params = null)
     {
+        try {
+            if (empty($params['customfields']['account_id'])) {
+                return [
+                    'success' => false,
+                    'error' => 'Custom Field /Account ID/ is not empty'
+                ];
+            }
 
+            $api = new PlanetHosterAPI(
+                $params['serverhostname'],
+                $params['serverusername'],
+                $params['serverpassword'],
+                $params['serverhttpprefix']
+            );
+
+            $result = $api->loginPanel($params['customfields']['account_id']);
+            if (!empty($result['data']['login_url'])) {
+                return [
+                    'success' => true,
+                    'redirectTo' => $result['data']['login_url']
+                ];
+            }
+            return [
+                'success' => false,
+                'error' => 'SSO URL not found'
+            ];
+        } catch (\Exception $e) {
+            return [
+                'success' => false,
+                'error' => $e->getMessage()
+            ];
+        }
     }
 }


### PR DESCRIPTION
…irectTo'=>url] pour ServiceSingleSignOn et AdminSingleSignOn. Correction du nom de la fonction dans base.php. Le SSO fonctionne désormais côté client et admin. #support #whmcs #sso